### PR TITLE
#17 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ RUN apt-get update && \
     cmake \
     make \
     build-essential \
+    gdb\
+    gdbserver\
+    rsync\
+    openssh-server\
     zlib1g-dev && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -24,6 +24,7 @@ struct StmtNode;
 struct IdentifierNode;
 // type def
 struct TypeNode;
+struct SimpleTypeNode;
 struct StringTypeNode;
 struct ConstValueNode;
 // 字面量相关
@@ -33,6 +34,7 @@ struct IntegerNode;
 struct CharNode;
 struct BoolenNode;
 // 表达式相关
+struct BinopExprNode;
 struct FuncExprNode;
 struct SysRoutineNode;
 struct SysCallNode;
@@ -49,6 +51,7 @@ struct HeadListNode;
 struct RoutineNode;
 struct ProgramNode;
 struct CompoundStmtNode;
+struct AssignStmtNode;
 struct ProcStmtNode;
 struct StmtList;
 
@@ -193,6 +196,9 @@ struct StringTypeNode : public TypeNode {
 };
 
 struct ConstValueNode : public ExprNode {
+ public:
+  llvm::Type *get_llvm_type(CodegenContext &context) const;
+
  protected:
   ConstValueNode() { type = nullptr; }
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -343,11 +343,24 @@ struct FuncExprNode : public ExprNode {
 enum class SysRoutine {
   /// 输出并回车
   WRITELN,
-  WRITE
+  WRITE,
+  READ,
+  READLN,
+  SQRT,
+  ABS,
+  ORD,
+  PRED,
+  SUCC,
+  CHR
 };
 
 inline std::string to_string(SysRoutine routine) {
-  std::map<SysRoutine, std::string> routine_to_string{{SysRoutine::WRITELN, "writeln"}, {SysRoutine::WRITE, "write"}};
+  std::map<SysRoutine, std::string> routine_to_string{
+      {SysRoutine::WRITELN, "writeln"}, {SysRoutine::WRITE, "write"}, {SysRoutine::READ, "read"},
+      {SysRoutine::READLN, "readln"},   {SysRoutine::SQRT, "sqrt"},   {SysRoutine::ABS, "abs"},
+      {SysRoutine::ORD, "ord"},         {SysRoutine::PRED, "pred"},   {SysRoutine::SUCC, "succ"},
+      {SysRoutine::CHR, "chr"}
+  };
   // TODO: bound checking
   return routine_to_string[routine];
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -88,7 +88,21 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
       } else {
         throw CodegenException("unsupported built-in routine: " + to_string(routine->routine));
       }
+      return nullptr;
     }
+
+    case SysRoutine::SQRT:
+      break;
+    case SysRoutine::ABS:
+      break;
+    case SysRoutine::ORD:
+      break;
+    case SysRoutine::PRED:
+      break;
+    case SysRoutine::SUCC:
+      break;
+    case SysRoutine::CHR:
+      break;
 
     default:
       break;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -63,6 +63,8 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
         std::vector<llvm::Value *> args;
         /*添加空指针判断*/
         auto ptr = cast_node<IdentifierNode>(arg)->get_ptr(context);
+        if(ptr == nullptr)
+          throw CodegenException("identifier not found: " + cast_node<IdentifierNode>(arg)->name);
         if (ptr->getType()->getPointerElementType()->isIntegerTy(8)) {
           args.push_back(context.builder.CreateGlobalStringPtr("%c"));
           args.push_back(ptr);
@@ -88,10 +90,10 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
     }
 
     case SysRoutine::SQRT:{
-      auto sqrt_type = llvm::FunctionType::get(context.builder.getDoubleTy(), context.builder.getDoubleTy(), false);
-      auto sqrt_func = context.module->getOrInsertFunction("sqrt", sqrt_type);
       if(args->children().size() != 1)
         throw CodegenException("no matching function for call to 'sqrt'");
+      auto sqrt_type = llvm::FunctionType::get(context.builder.getDoubleTy(), context.builder.getDoubleTy(), false);
+      auto sqrt_func = context.module->getOrInsertFunction("sqrt", sqrt_type);
       auto arg = *args->children().begin();
       auto value = arg->codegen(context);
       if (!(value->getType()->isIntegerTy(32) || value->getType()->isDoubleTy())) {
@@ -104,10 +106,10 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
       return context.builder.CreateCall(sqrt_func, args);
     }
     case SysRoutine::ABS:{
-      auto fabs_type = llvm::FunctionType::get(context.builder.getDoubleTy(), context.builder.getDoubleTy(), false);
-      auto fabs_func = context.module->getOrInsertFunction("fabs", fabs_type);
       if(args->children().size() != 1)
         throw CodegenException("no matching function for call to 'abs'");
+      auto fabs_type = llvm::FunctionType::get(context.builder.getDoubleTy(), context.builder.getDoubleTy(), false);
+      auto fabs_func = context.module->getOrInsertFunction("fabs", fabs_type);
       auto arg = *args->children().begin();
       auto value = arg->codegen(context);
       if (!(value->getType()->isIntegerTy(32) || value->getType()->isDoubleTy()))
@@ -128,7 +130,7 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
       return context.builder.CreateZExt(value, context.builder.getInt32Ty());
     }
     case SysRoutine::PRED:
-      break;
+      //只支持字符和整数
     case SysRoutine::SUCC:
       break;
     case SysRoutine::CHR:

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -137,9 +137,9 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
         if (!(value->getType()->isIntegerTy(8) || value->getType()->isIntegerTy(32)))
           throw CodegenException("incompatible type in pred(): expected char, int");
         if (value->getType()->isIntegerTy(32))
-          return context.builder.CreateSub(value, llvm::ConstantInt::get(context.builder.getInt32Ty(), 1, true));
+          return context.builder.CreateSub(value, context.builder.getInt32(1));
         else
-          return context.builder.CreateSub(value, llvm::ConstantInt::get(context.builder.getInt8Ty(), 1, false));
+          return context.builder.CreateSub(value, context.builder.getInt8(1));
       }
     case SysRoutine::SUCC:{
         //只支持字符和整数
@@ -149,13 +149,18 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
         if (!(value->getType()->isIntegerTy(8) || value->getType()->isIntegerTy(32)))
           throw CodegenException("incompatible type in succ(): expected char, int");
         if (value->getType()->isIntegerTy(32))
-          return context.builder.CreateAdd(value, llvm::ConstantInt::get(context.builder.getInt32Ty(), 1));
+          return context.builder.CreateAdd(value, context.builder.getInt32(1));
         else
-          return context.builder.CreateAdd(value, llvm::ConstantInt::get(context.builder.getInt8Ty(), 1));
+          return context.builder.CreateAdd(value, context.builder.getInt8(1));
       }
-    case SysRoutine::CHR:
-      break;
-
+    case SysRoutine::CHR:{
+        if (args->children().size() != 1) throw CodegenException("no matching function for call to 'chr'");
+        auto arg = *args->children().begin();
+        auto value = arg->codegen(context);
+        if (!value->getType()->isIntegerTy(32))
+          throw CodegenException("incompatible type in chr(): expected int");
+        return context.builder.CreateTrunc(value, context.builder.getInt8Ty());
+      }
     default:
       throw CodegenException("unsupported built-in routine: " + to_string(routine->routine));
   }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -81,11 +81,8 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
         context.builder.CreateRet(context.builder.CreateCall(scanf_func, args));
       }
       if (routine->routine == SysRoutine::READLN) {
-        /*auto getchar_type = llvm::FunctionType::get(context.builder.getInt32Ty(), false);
-        auto getchar_func = context.module->getOrInsertFunction("getchar", getchar_type);
-        llvm::Value* ret = context.builder.CreateCall(getchar_func);
-        while(){
-        }*/
+        context.builder.CreateRet(context.builder.CreateCall(scanf_func,context.builder.CreateGlobalStringPtr("[^\\n\\r]*")));
+        context.builder.CreateRet(context.builder.CreateCall(scanf_func,context.builder.CreateGlobalStringPtr("[\\r]？[\\n]")));
       }
       return nullptr;
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -55,23 +55,21 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
     for (auto &arg : args->children()) {
       auto value = arg->codegen(context);
       std::vector<llvm::Value *> args;
+      auto name = cast_node<LeftValueExprNode>(arg)->name;
+      std::shared_ptr<Symbol> symbol = context.symbolTable.getGlobalSymbol(name);
+      if (context.symbolTable.getGlobalSymbol(name))
+        symbol = context.symbolTable.getLocalSymbol(name);
+      if(!symbol)
+        throw CodegenException("Use of undeclared identifier in read()");
+
       if (value->getType()->isIntegerTy(8)) {
         args.push_back(context.builder.CreateGlobalStringPtr("%c"));
-        std::shared_ptr<Symbol> symbol = context.symbolTable.getGlobalSymbol(arg.name);
-        if (context.symbolTable.getGlobalSymbol(arg.name))
-          symbol = context.symbolTable.getLocalSymbol(arg.name);
         args.push_back(symbol->get_llvmptr());
       } else if (value->getType()->isIntegerTy()) {
         args.push_back(context.builder.CreateGlobalStringPtr("%d"));
-        std::shared_ptr<Symbol> symbol = context.symbolTable.getGlobalSymbol(arg.name);
-        if (context.symbolTable.getGlobalSymbol(arg.name))
-          symbol = context.symbolTable.getLocalSymbol(arg.name);
         args.push_back(symbol->get_llvmptr());
       } else if (value->getType()->isDoubleTy()) {
         args.push_back(context.builder.CreateGlobalStringPtr("%f"));
-        std::shared_ptr<Symbol> symbol = context.symbolTable.getGlobalSymbol(arg.name);
-        if (context.symbolTable.getGlobalSymbol(arg.name))
-          symbol = context.symbolTable.getLocalSymbol(arg.name);
         args.push_back(symbol->get_llvmptr());
       }
       else {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -104,8 +104,20 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
       args.push_back(arg->codegen(context));
       return context.builder.CreateCall(sqrt_func, args);
     }
-    case SysRoutine::ABS:
-      break;
+    case SysRoutine::ABS:{
+      auto abs_type = llvm::FunctionType::get(context.builder.getDoubleTy(), context.builder.getDoubleTy(), false);
+      auto abs_func = context.module->getOrInsertFunction("abs", abs_type);
+      if(args->children().size() != 1)
+        throw CodegenException("no matching function for call to 'abs'");
+      auto arg = *args->children().begin();
+      auto value = arg->codegen(context);
+      if (!(value->getType()->isIntegerTy(32) || value->getType()->isDoubleTy())) {
+        throw CodegenException("incompatible type in abs(): expected integer, real");
+      }
+      std::vector<llvm::Value *> args;
+      args.push_back(arg->codegen(context));
+      return context.builder.CreateCall(abs_func, args);
+    }
     case SysRoutine::ORD:
       break;
     case SysRoutine::PRED:

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -53,10 +53,20 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
 /* -------- type nodes -------- */
 static llvm::Type *llvm_type(Type type, CodegenContext &context) {
   switch (type) {
+    case Type::BOOLEN:
+      return context.builder.getInt1Ty();
+    case Type::INTEGER:
+      return context.builder.getInt32Ty();
+    case Type::REAL:
+      return context.builder.getDoubleTy();
+    case Type::CHAR:
+      return context.builder.getInt8Ty();
     default:
       return nullptr;
   }
 }
+
+llvm::Type *ConstValueNode::get_llvm_type(CodegenContext &context) const { return this->type->get_llvm_type(context); }
 
 llvm::Type *TypeNode::get_llvm_type(CodegenContext &context) const {
   if (auto *simple_type = dynamic_cast<const SimpleTypeNode *>(this)) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -128,15 +128,7 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
       auto value = arg->codegen(context);
       if (!value->getType()->isIntegerTy(8))
         throw CodegenException("incompatible type in ord(): expected char");
-      if(is_a_ptr_of<IdentifierNode>(arg)) {
-        auto node = cast_node<IdentifierNode>(arg);
-        return llvm::ConstantInt::getSigned(context.builder.getInt32Ty(),
-            llvm::cast<llvm::ConstantInt>(node->get_ptr(context))->getSExtValue());
-      }else if(is_a_ptr_of<CharNode>(arg)){
-        return llvm::ConstantInt::getSigned(context.builder.getInt32Ty(),
-                                            llvm::cast<llvm::ConstantInt>(value)->getSExtValue());
-      }else
-        throw CodegenException("error node type in ord(): expected IdentifierNode, CharNode");
+      return context.builder.CreateZExt(value, context.builder.getInt32Ty());
     }
     case SysRoutine::PRED:
       break;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -101,12 +101,14 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
         throw CodegenException("incompatible type in sqrt(): expected integer, real");
       }
       std::vector<llvm::Value *> args;
-      args.push_back(arg->codegen(context));
+      if(value->getType()->isIntegerTy(32))
+        value = context.builder.CreateUIToFP(value,context.builder.getDoubleTy());
+      args.push_back(value);
       return context.builder.CreateCall(sqrt_func, args);
     }
     case SysRoutine::ABS:{
-      auto abs_type = llvm::FunctionType::get(context.builder.getDoubleTy(), context.builder.getDoubleTy(), false);
-      auto abs_func = context.module->getOrInsertFunction("abs", abs_type);
+      auto fabs_type = llvm::FunctionType::get(context.builder.getDoubleTy(), context.builder.getDoubleTy(), false);
+      auto fabs_func = context.module->getOrInsertFunction("fabs", fabs_type);
       if(args->children().size() != 1)
         throw CodegenException("no matching function for call to 'abs'");
       auto arg = *args->children().begin();
@@ -114,8 +116,10 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
       if (!(value->getType()->isIntegerTy(32) || value->getType()->isDoubleTy()))
         throw CodegenException("incompatible type in abs(): expected integer, real");
       std::vector<llvm::Value *> args;
-      args.push_back(arg->codegen(context));
-      return context.builder.CreateCall(abs_func, args);
+      if(value->getType()->isIntegerTy(32))
+        value = context.builder.CreateUIToFP(value,context.builder.getDoubleTy());
+      args.push_back(value);
+      return context.builder.CreateCall(fabs_func, args);
     }
     case SysRoutine::ORD:{
       if(args->children().size() != 1)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -55,22 +55,16 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
     for (auto &arg : args->children()) {
       auto value = arg->codegen(context);
       std::vector<llvm::Value *> args;
-      auto name = cast_node<LeftValueExprNode>(arg)->name;
-      std::shared_ptr<Symbol> symbol = context.symbolTable.getGlobalSymbol(name);
-      if (context.symbolTable.getGlobalSymbol(name))
-        symbol = context.symbolTable.getLocalSymbol(name);
-      if(!symbol)
-        throw CodegenException("Use of undeclared identifier in read()");
-
+      auto ptr = cast_node<IdentifierNode>(arg)->get_ptr(context);
       if (value->getType()->isIntegerTy(8)) {
         args.push_back(context.builder.CreateGlobalStringPtr("%c"));
-        args.push_back(symbol->get_llvmptr());
+        args.push_back(ptr);
       } else if (value->getType()->isIntegerTy()) {
         args.push_back(context.builder.CreateGlobalStringPtr("%d"));
-        args.push_back(symbol->get_llvmptr());
+        args.push_back(ptr);
       } else if (value->getType()->isDoubleTy()) {
         args.push_back(context.builder.CreateGlobalStringPtr("%f"));
-        args.push_back(symbol->get_llvmptr());
+        args.push_back(ptr);
       }
       else {
           throw CodegenException("incompatible type in read(): expected char, integer, real");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7,7 +7,6 @@
 #include <llvm/IR/Verifier.h>
 
 #include <llvm/Support/Casting.h>
-#include <llvm/>
 // used by decl nodes
 #include <fmt/core.h>
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -129,10 +129,30 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
         throw CodegenException("incompatible type in ord(): expected char");
       return context.builder.CreateZExt(value, context.builder.getInt32Ty());
     }
-    case SysRoutine::PRED:
-      //只支持字符和整数
-    case SysRoutine::SUCC:
-      break;
+    case SysRoutine::PRED:{
+    //只支持字符和整数
+        if (args->children().size() != 1) throw CodegenException("no matching function for call to 'pred'");
+        auto arg = *args->children().begin();
+        auto value = arg->codegen(context);
+        if (!(value->getType()->isIntegerTy(8) || value->getType()->isIntegerTy(32)))
+          throw CodegenException("incompatible type in pred(): expected char, int");
+        if (value->getType()->isIntegerTy(32))
+          return context.builder.CreateSub(value, llvm::ConstantInt::get(context.builder.getInt32Ty(), 1, true));
+        else
+          return context.builder.CreateSub(value, llvm::ConstantInt::get(context.builder.getInt8Ty(), 1, false));
+      }
+    case SysRoutine::SUCC:{
+        //只支持字符和整数
+        if (args->children().size() != 1) throw CodegenException("no matching function for call to 'succ'");
+        auto arg = *args->children().begin();
+        auto value = arg->codegen(context);
+        if (!(value->getType()->isIntegerTy(8) || value->getType()->isIntegerTy(32)))
+          throw CodegenException("incompatible type in succ(): expected char, int");
+        if (value->getType()->isIntegerTy(32))
+          return context.builder.CreateAdd(value, llvm::ConstantInt::get(context.builder.getInt32Ty(), 1));
+        else
+          return context.builder.CreateAdd(value, llvm::ConstantInt::get(context.builder.getInt8Ty(), 1));
+      }
     case SysRoutine::CHR:
       break;
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -45,10 +45,10 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
           else
             throw CodegenException("incompatible type in writeln(): expected char, integer, real");
         }
-        context.builder.CreateRet(context.builder.CreateCall(printf_func, args));
+        context.builder.CreateCall(printf_func, args);
       }
       if (routine->routine == SysRoutine::WRITELN) {
-        context.builder.CreateRet(context.builder.CreateCall(printf_func, context.builder.CreateGlobalStringPtr("\n")));
+        context.builder.CreateCall(printf_func, context.builder.CreateGlobalStringPtr("\n"));
       }
       return nullptr;
     }
@@ -80,11 +80,11 @@ llvm::Value *SysCallNode::codegen(CodegenContext &context) {
           else
             throw CodegenException("incompatible type in readln(): expected char, integer, real");
         }
-        context.builder.CreateRet(context.builder.CreateCall(scanf_func, args));
+        context.builder.CreateCall(scanf_func, args);
       }
       if (routine->routine == SysRoutine::READLN) {
-        context.builder.CreateRet(context.builder.CreateCall(scanf_func,context.builder.CreateGlobalStringPtr("[^\\n\\r]*")));
-        context.builder.CreateRet(context.builder.CreateCall(scanf_func,context.builder.CreateGlobalStringPtr("[\\r]？[\\n]")));
+        context.builder.CreateCall(scanf_func,context.builder.CreateGlobalStringPtr("[^\\n\\r]*"));
+        context.builder.CreateCall(scanf_func,context.builder.CreateGlobalStringPtr("[\\r]？[\\n]"));
       }
       return nullptr;
     }

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -50,43 +50,6 @@ struct CodegenContext final {
       mpm->add(llvm::createFunctionInliningPass());  // 函数内联 这个加不加区别不大
     }
   }
-  /*
-      llvm::Value *get_local(std::string key)
-      {
-          auto it = locals.find(key);
-          if (it != locals.end()) return it->second;
-          else return nullptr;
-      }
-      bool set_local(std::string key, llvm::Value *value)
-      {
-          if (get_local(key)) return false;
-          locals[key] = value;
-          return true;
-      }
-      void reset_locals()
-      {
-          locals.clear();
-          localsType.clear();
-      }
-      llvm::Type *get_alias(std::string key)
-      {
-          auto it = aliases.find(key);
-          if (it != aliases.end()) return it->second;
-          else return nullptr;
-      }
-      bool set_alias(std::string key, llvm::Type *value)
-      {
-          if (get_alias(key)) return false;
-          aliases[key] = value;
-          return true;
-      }
-
-  private:
-      std::map<std::string,std::shared_ptr<TypeNode>> globalsType; //全局变量的类型
-      std::map<std::string,llvm::Value*> locals; //局部变量
-      std::map<std::string,std::shared_ptr<TypeNode>> localsType; //局部变量的类型
-      std::map<std::string,llvm::Type*> aliases; //类型别名
-  */
 };
 /// 代码生成异常类，是std::exception的派生类 用来输出在编译时遇到的错误
 class CodegenException : public std::exception {


### PR DESCRIPTION
关于read：
       调用scanf函数的function_type和creat_call模仿/了已经完成的write，在网络上找到了另一种方式，在FunctionType以及调用上有所区别，是scanf和printf有差别还是两种都行呢。这种系统函数的调用格式可以在哪里查到呢？
```
llvm::FunctionType *readFnType = llvm::FunctionType::get(builder.getInt32Ty(), true); 
llvm::Function* readfn = llvm::Function::Create(readFnType, llvm::GlobalValue::ExternalLinkage, "scanf", TheModule));
std::vector<Value*> ArgsV; // holds codegen IR for each argument
std::string StringFormat; // holds string formatting for all arguments
for(auto& arg : Args){
        if(auto v = arg->codegen()){ 
            if(v->getType()->isDoubleTy())
                StringFormat += "%lf "; // 
            else if(v->getType()->isIntegerTy())
                StringFormat += "%d ";
            ArgsV.push_back(symbolTable[arg.name]);
        }else return nullptr;
    }
ArgsV.insert(ArgsV.begin(), builder.CreateGlobalStringPtr(StringFormat));
builder.CreateCall(TheModule->getFunction("scanf"), ArgsV, "scanfCall");
```

