### PR TITLE
#18 增加关于controlflow语法分析，修改LoopStmtNode及IfStmtNode

### DIFF
--- a/test/controlflow.pas
+++ b/test/controlflow.pas
@@ -3,10 +3,9 @@ const
   ZERO = 0;
   ONE = 1;
   TWO = 2;
-type
-  int = integer;
+
 var
-  x, y, i: int;
+  x, y, i: integer;
 
 begin
   readln(x, y);


### PR DESCRIPTION
将controlflow去掉类型定义后可以已经可以跑通，系统类型别名是放在实现book_struct里提交还是在这里提交
即若修改
```
type
  int = integer;
var
  x, y, i: int;
```
为
```
var
  x, y, i: integer;
```
就可以跑通